### PR TITLE
Enable scraping license infos

### DIFF
--- a/.github/workflows/anx-ci.yml
+++ b/.github/workflows/anx-ci.yml
@@ -9,7 +9,7 @@ on:
 name: anx-ci
 jobs:
   test:
-    if: github.repository == ‘anexia/junos_exporter’
+    # if: github.repository == ‘anexia/junos_exporter’
     strategy:
       matrix:
         go-version: [1.18.x]
@@ -29,7 +29,7 @@ jobs:
         run: go test ./... -v -covermode=count
 
   publish:
-    if: github.repository == ‘anexia/junos_exporter’
+    # if: github.repository == ‘anexia/junos_exporter’
     needs: test
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/anx-ci.yml
+++ b/.github/workflows/anx-ci.yml
@@ -1,0 +1,70 @@
+on:
+  push:
+    branches:
+      - anx-prod
+  pull_request:
+    branches:
+      - "**"
+
+name: anx-ci
+jobs:
+  test:
+    if: github.repository == ‘anexia/junos_exporter’
+    strategy:
+      matrix:
+        go-version: [1.18.x]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Install Go
+        if: success()
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build
+        run: go build
+      - name: Run tests
+        run: go test ./... -v -covermode=count
+
+  publish:
+    if: github.repository == ‘anexia/junos_exporter’
+    needs: test
+    runs-on: ubuntu-latest
+    env:
+      S3_URL: ${{secrets.S3_URL}}
+      S3_BUCKET: ${{secrets.S3_BUCKET}}
+      S3_ACCESS_KEY: ${{secrets.S3_ACCESS_KEY}}
+      S3_SECRET_KEY: ${{secrets.S3_SECRET_KEY}}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Build
+        run: go build .
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: junos_exporter
+          path: junos_exporter
+
+      - uses: actions/setup-python@v4
+
+      - name: publish anx-prod to s3://$S3_BUCKET/junos_images/junos_exporter/$GITHUB_REF_NAME/junos_exporter
+        run: |
+          pip install s4cmd
+          s4cmd put --endpoint-url https://$S3_URL -f junos_exporter s3://$S3_BUCKET/junos_images/junos_exporter/$GITHUB_REF_NAME/junos_exporter
+        if: github.ref_type == 'tag' || github.ref == 'refs/heads/anx-prod'
+
+      - name: "publish feature-branch to s3://$S3_BUCKET/junos_images/junos_exporter/staging/junos_exporter"
+        run: |
+          pip install s4cmd
+          s4cmd put --endpoint-url https://$S3_URL -f junos_exporter s3://$S3_BUCKET/junos_images/junos_exporter/staging/junos_exporter
+        # value only there if pull_request or pull_request_target
+        if: github.head_ref

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Please have a look on the new SSH related parameters and update your service uni
 ## Features
 The following metrics are supported by now:
 * Interfaces (bytes transmitted/received, errors, drops, speed)
+* Interface L1/L2 details (FEC, MAC statistics)
+* L2 security (BPDU-block violations)
 * Routes (per table, by protocol)
 * Alarms (count)
 * BGP (message count, prefix counts per peer, session state)
@@ -43,10 +45,18 @@ The following metrics are supported by now:
 * Storage (total, available and used blocks, used percentage)
 * Firewall filters (counters and policers) - needs explicit rights beyond read-only
 * Security policy (SRX) statistics
-* Statistics about l2circuits (tunnel state, number of tunnels)
 * Interface queue statistics
 * Power (Power usage)
 * License statistics (installed/used/needed)
+* L2circuits (tunnel state, number of tunnels)
+* LDP (number of neighbors, sessions and session states)
+* VRRP (state per interface)
+
+
+## Feature specific mappings
+Some collected time series behave like enums - Integer values represent a certain state/meaning.
+
+### L2circuits
 ```   
 0:EI -- encapsulation invalid
 1:MM -- mtu mismatch
@@ -72,14 +82,14 @@ The following metrics are supported by now:
 21:RS -- remote site standby
 22:HS -- Hot-standby Connection
 ```
-* LDP (number of neighbors, sessions and session states)
-States map to human readable names like this:
+
+### LDP
 ```   
 0: "Nonexistant"
 1: "Operational"
 ```
-* RPKI Session Information
-States map to human readable names like this:
+
+### RPKI
 ```
 0 = "Down"
 1 = "Up"
@@ -88,12 +98,22 @@ States map to human readable names like this:
 4 = "Ex-Incr"
 5 = "Ex-Full"
 ```
-* VRRP (state per interface)
+
+### VRRP
 States map to human readable names like this:
 ```   
 1: "init"
 2: "backup"
 3: "master"
+```
+
+### License statistics
+Expiry is either presented as number of days until expiry date or certain special values.
+```
+0 ... n = Days until expiry
+     -1 = Expired 
+   +Inf = Permanent license
+   -Inf = Invalid
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following metrics are supported by now:
 * Statistics about l2circuits (tunnel state, number of tunnels)
 * Interface queue statistics
 * Power (Power usage)
+* License statistics (installed/used/needed)
 ```   
 0:EI -- encapsulation invalid
 1:MM -- mtu mismatch

--- a/collectors.go
+++ b/collectors.go
@@ -104,7 +104,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device) {
 	c.addCollectorIfEnabledForDevice(device, "security", f.Security, security.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "security_policies", f.SecurityPolicies, securitypolicies.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "storage", f.Storage, storage.NewCollector)
-	c.addCollectorIfEnabledForDevice(device, "system", f.System, system.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "system", (f.System || f.License), system.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "power", f.Power, power.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "mac", f.MAC, mac.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "vrrp", f.VRRP, vrrp.NewCollector)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,7 @@ type FeatureConfig struct {
 	MPLSLSP             bool `yaml:"mpls_lsp,omitempty"`
 	VPWS                bool `yaml:"vpws,omitempty"`
 	VRRP                bool `yaml:"vrrp,omitempty"`
+	License             bool `yaml:"license,omitempty"`
 }
 
 // New creates a new config
@@ -134,6 +135,7 @@ func setDefaultValues(c *Config) {
 	f.VPWS = false
 	f.VRRP = false
 	f.BFD = false
+	f.License = false
 }
 
 // FeaturesForDevice gets the feature set configured for a device

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -105,6 +105,10 @@ func clientForDevice(device *connector.Device, connManager *connector.SSHConnect
 		c.EnableSatellite()
 	}
 
+	if cfg.Features.License {
+		c.EnableLicense()
+	}
+
 	return c, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ var (
 	macEnabled                  = flag.Bool("mac.enabled", false, "Scrape MAC address table metrics")
 	alarmFilter                 = flag.String("alarms.filter", "", "Regex to filter for alerts to ignore")
 	configFile                  = flag.String("config.file", "", "Path to config file")
-	dynamicIfaceLabels          = flag.Bool("dynamic-interface-labels", true, "Parse interface descriptions to get labels dynamicly")
+	dynamicIfaceLabels          = flag.Bool("dynamic-interface-labels", true, "Parse interface descriptions to get labels dynamically")
 	interfaceDescriptionRegex   = flag.String("interface-description-regex", "", "give a regex to retrieve the interface description labels")
 	lsEnabled                   = flag.Bool("logical-systems.enabled", false, "Enable logical systems support")
 	powerEnabled                = flag.Bool("power.enabled", true, "Scrape power metrics")
@@ -70,6 +70,7 @@ var (
 	bfdEnabled                  = flag.Bool("bfd.enabled", false, "Scrape BFD metrics")
 	vpwsEnabled                 = flag.Bool("vpws.enabled", false, "Scrape EVPN VPWS metrics")
 	mplsLSPEnabled              = flag.Bool("mpls_lsp.enabled", false, "Scrape MPLS LSP metrics")
+	licenseEnabled              = flag.Bool("license.enabled", false, "Scrape license metrics")
 	cfg                         *config.Config
 	devices                     []*connector.Device
 	connManager                 *connector.SSHConnectionManager
@@ -223,6 +224,7 @@ func loadConfigFromFlags() *config.Config {
 	f.BFD = *bfdEnabled
 	f.VPWS = *vpwsEnabled
 	f.MPLSLSP = *mplsLSPEnabled
+	f.License = *licenseEnabled
 
 	return c
 }

--- a/pkg/features/system/collector.go
+++ b/pkg/features/system/collector.go
@@ -393,9 +393,6 @@ func (c *systemCollector) collectLicense(client *rpc.Client, ch chan<- prometheu
 
 	if err == nil {
 		for i := range r.LicenseInfo.License {
-			// licenseLabels = make([]string, 0)
-			// 	l = append(l, "feature_name", "feature_description", "expiry")
-
 			licenseLabels := append(labelValues,
 				strings.ToLower(r.LicenseInfo.License[i].Name),
 				strings.ToLower(r.LicenseInfo.License[i].Description),

--- a/pkg/features/system/rpc.go
+++ b/pkg/features/system/rpc.go
@@ -70,3 +70,16 @@ type satelliteChassis struct {
 		} `xml:"satellite"`
 	} `xml:"satellite-information"`
 }
+
+type licenseInformation struct {
+	LicenseInfo struct {
+		License []struct {
+			Name  string `xml:"name"`
+			Description string `xml:"description"`
+			Installed  int `xml:"licensed"`
+			Used int `xml:"used-licensed"`
+			Needed int `xml:"needed"`
+			ValidityType string `xml:"validity-type"`
+		} `xml:"feature-summary"`
+	} `xml:"license-usage-summary"`
+}

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -17,6 +17,7 @@ type Client struct {
 	conn      *connector.SSHConnection
 	debug     bool
 	Satellite bool
+	License   bool
 }
 
 // NewClient creates a new client to connect to
@@ -70,4 +71,8 @@ func (c *Client) DisableDebug() {
 // EnableSatellite enables satellite device metrics gathering
 func (c *Client) EnableSatellite() {
 	c.Satellite = true
+}
+
+func (c *Client) EnableLicense() {
+	c.License = true
 }


### PR DESCRIPTION
This exposes the output of `show system license` (license name, description, count and expiry if applicable).